### PR TITLE
adapt to software container 2.9.1 and spack setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,6 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.15 FATAL_ERROR)
 
 PROJECT(TemplateWorkspace)
 
-INCLUDE("/opt/ilcsoft/muonc/ILCSoft.cmake")
-
 #
 # Find and add all packages
 FILE(GLOB packages RELATIVE ${CMAKE_CURRENT_LIST_DIR} packages/*)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Template Workspace
 
-Template for developing custom Marlin packages.
+Template for developing custom Marlin packages. Fork this repository and rename to create your own project.
 
 ## Repository Structure
 - `exts/` External packages not included with the ILC framework.
@@ -9,29 +9,29 @@ Template for developing custom Marlin packages.
 ## Setup Instructions
 
 ### Container
-All commands should be run inside the `infnpd/mucoll-ilc-framework:1.6-centos8` image.
+All commands are compatible and should be run inside the latest `gitlab-registry.cern.ch/muon-collider/muoncollider-docker/mucoll-sim:master-alma9` image (versions 2.8 and above).
 
 #### Apptainer
 ```bash
-apptainer shell --cleanenv docker://infnpd/mucoll-ilc-framework:1.6-centos8
+apptainer shell --cleanenv gitlab-registry.cern.ch/muon-collider/muoncollider-docker/mucoll-sim:master-alma9
 ```
 
 #### Shifter
 ```bash
-shifter --image infnpd/mucoll-ilc-framework:1.6-centos8 /bin/bash
+shifter --image gitlab-registry.cern.ch/muon-collider/muoncollider-docker/mucoll-sim:master-alma9 /bin/bash
 ```
 
 ### Build Instructions
-Run the following commands from inside your container. The same commands will also work with a local installation of the ILC software, with the exception of the first line.
+Run the following commands from inside your container. The same commands will also work with a local installation of the ILC and Key4Hep software, with the exception of the first line.
 ```bash
-source /opt/ilcsoft/muonc/init_ilcsoft.sh # Setup ILC software
+source /opt/setup_mucoll.sh # Setup software
 cmake -S . -B build 
 cmake --build build
 ```
 
 ### Setup Script
 The included `setup.sh` script is useful for defining all paths for the binaries built by the workspace. At the current stage, it setups the following:
-- ILC software via `init_ilcsoft.sh`
+- software via `init_mucoll.sh`
 - External binaries/libraries found in `exts`.
 - Add all package libraries to `MARLIN_DLL`.
 - Export `MYBUILD` variable with absolute path to the build directory.

--- a/setup.sh
+++ b/setup.sh
@@ -21,7 +21,10 @@ export MYBUILD=$(realpath ${MYBUILD})
 
 #
 # Main software
-source /opt/ilcsoft/muonc/init_ilcsoft.sh
+if [ -z "${MUCOLL_RELEASE_VERSION}" ]; then
+    #Setup Muon Collider software
+    source /opt/setup_mucoll.sh
+fi
 
 #
 # Add exts


### PR DESCRIPTION
- Remove inclusion of ILC software makefile.
- adapt setup script path and protect against multiple sourcing of the same file
- tested against [TemplatePackage](https://github.com/MuonColliderSoft/TemplatePackage/)
